### PR TITLE
Reconnect and resume interrupted log follows

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -114,40 +114,36 @@ func (client *Client) ListServices(project, service string) ([]Service, error) {
 // stream reconnects and resumes if the connection is cut.
 func (client *Client) StreamServiceLogs(project, service string, w io.Writer, follow, tail bool, skip int) error {
 	base := fmt.Sprintf("/projects/%s/services/%s/logs", project, service)
-	logPath := func(seek string, lines int) string {
-		params := url.Values{}
-		params.Set("seek", seek)
-		params.Set("skip", strconv.Itoa(lines))
+	logPath := func(params url.Values) string {
 		if follow {
 			params.Set("follow", "true")
 			params.Set("keepalive", keepaliveInterval.String())
 		}
 		return base + "?" + params.Encode()
 	}
-	if !follow {
-		seek := "start"
-		if tail {
-			seek = "end"
-		}
-		return client.streamOnce(logPath(seek, skip), w)
-	}
+	seek := "start"
 	if tail {
-		// A tail is anchored to the end of the log, so there is no absolute
-		// line to resume from: a reconnect re-anchors to the current end.
-		first := true
-		return client.follow(followOptions{path: func(int) string {
-			back := skip
-			if !first {
-				back = 0
-			}
-			first = false
-			return logPath("end", back)
-		}}, w)
+		seek = "end"
 	}
-	return client.follow(followOptions{
-		skipped: skip,
-		path:    func(resumeAfter int) string { return logPath("start", resumeAfter) },
-	}, w)
+	start := url.Values{"seek": {seek}, "skip": {strconv.Itoa(skip)}}
+	if !follow {
+		return client.streamOnce(logPath(start), w)
+	}
+	// A stream that starts at the beginning of the log resumes at an exact byte
+	// offset. One anchored to the end of the log, or started at a line offset,
+	// has no absolute position to resume from, so it re-anchors to the current
+	// end and may miss lines written while reconnecting.
+	exact := !tail && skip == 0
+	return client.follow(followOptions{path: func(resumeAfter int) string {
+		switch {
+		case resumeAfter == 0:
+			return logPath(start)
+		case exact:
+			return logPath(url.Values{"seek": {"start"}, "offset": {strconv.Itoa(resumeAfter)}})
+		default:
+			return logPath(url.Values{"seek": {"end"}})
+		}
+	}}, w)
 }
 
 // SubmitArtifact submits a new build input artifact to the server.
@@ -288,7 +284,7 @@ func (client *Client) StreamBuildLogs(project, service, id string, consumer func
 			params := url.Values{}
 			params.Set("follow", "true")
 			params.Set("keepalive", keepaliveInterval.String())
-			params.Set("skip", strconv.Itoa(resumeAfter))
+			params.Set("offset", strconv.Itoa(resumeAfter))
 			return base + "?" + params.Encode()
 		},
 	}, decoder)

--- a/api/client.go
+++ b/api/client.go
@@ -25,7 +25,10 @@ type Client struct {
 	Endpoint string
 	Token    string
 
-	http *http.Client
+	// http carries buffered requests, stream carries log streams. They are
+	// separate because a stream must not inherit a request deadline.
+	http   *http.Client
+	stream *http.Client
 }
 
 func (client *Client) UserInfo() (*UserInfo, error) {
@@ -66,37 +69,7 @@ func parseErrorResponse(body []byte) error {
 	return serverErr
 }
 
-func (client *Client) streamRequest(method, path string, w io.Writer) error {
-	client.http.Timeout = 0
-	req, err := http.NewRequest(method, client.Endpoint+path, nil)
-	if err != nil {
-		return fmt.Errorf("client request: %w", err)
-	}
-	req.Header.Add("Authorization", "Bearer "+client.Token)
-
-	resp, err := client.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("submitting request: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("fetching response: %w", err)
-		}
-		return Error{
-			StatusCode:  resp.StatusCode,
-			ServerError: parseErrorResponse(body),
-		}
-	}
-	if _, err := io.Copy(w, resp.Body); err != nil && err != io.EOF {
-		return fmt.Errorf("copying request: %w", err)
-	}
-	return nil
-}
-
 func (client *Client) request(method, path string, obj interface{}, post io.Reader) error {
-	client.http.Timeout = time.Minute
 	req, err := http.NewRequest(method, client.Endpoint+path, post)
 	if err != nil {
 		return fmt.Errorf("client request: %w", err)
@@ -137,25 +110,44 @@ func (client *Client) ListServices(project, service string) ([]Service, error) {
 	return services, nil
 }
 
-// StreamServiceLogs streams the logs of the latest service endpoint.
+// StreamServiceLogs streams the logs of the latest service endpoint. A followed
+// stream reconnects and resumes if the connection is cut.
 func (client *Client) StreamServiceLogs(project, service string, w io.Writer, follow, tail bool, skip int) error {
-	params := url.Values{}
-	if follow {
-		params.Set("follow", "true")
+	base := fmt.Sprintf("/projects/%s/services/%s/logs", project, service)
+	logPath := func(seek string, lines int) string {
+		params := url.Values{}
+		params.Set("seek", seek)
+		params.Set("skip", strconv.Itoa(lines))
+		if follow {
+			params.Set("follow", "true")
+			params.Set("keepalive", keepaliveInterval.String())
+		}
+		return base + "?" + params.Encode()
+	}
+	if !follow {
+		seek := "start"
+		if tail {
+			seek = "end"
+		}
+		return client.streamOnce(logPath(seek, skip), w)
 	}
 	if tail {
-		params.Set("seek", "end")
-	} else {
-		params.Set("seek", "start")
+		// A tail is anchored to the end of the log, so there is no absolute
+		// line to resume from: a reconnect re-anchors to the current end.
+		first := true
+		return client.follow(followOptions{path: func(int) string {
+			back := skip
+			if !first {
+				back = 0
+			}
+			first = false
+			return logPath("end", back)
+		}}, w)
 	}
-	params.Set("skip", strconv.Itoa(skip))
-	var (
-		path = fmt.Sprintf("/projects/%s/services/%s/logs?%s", project, service, params.Encode())
-	)
-	if err := client.streamRequest(http.MethodGet, path, w); err != nil {
-		return err
-	}
-	return nil
+	return client.follow(followOptions{
+		skipped: skip,
+		path:    func(resumeAfter int) string { return logPath("start", resumeAfter) },
+	}, w)
 }
 
 // SubmitArtifact submits a new build input artifact to the server.
@@ -233,13 +225,17 @@ type logEntryDecoder struct {
 	consumer func(LogEntry)
 	writer   *io.PipeWriter
 	done     chan struct{}
+	err      error
 }
 
 func newLogEntryDecoder(consumer func(LogEntry)) *logEntryDecoder {
-	done := make(chan struct{}, 1)
+	decoder := &logEntryDecoder{consumer: consumer, done: make(chan struct{})}
 	reader, writer := io.Pipe()
+	decoder.writer = writer
 	go func() {
+		defer close(decoder.done)
 		scanner := bufio.NewScanner(reader)
+		scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxLogFrameSize)
 		for scanner.Scan() {
 			logentry := LogEntry{}
 			logline := scanner.Text()
@@ -249,22 +245,26 @@ func newLogEntryDecoder(consumer func(LogEntry)) *logEntryDecoder {
 			}
 			consumer(logentry)
 		}
-		close(done)
+		decoder.err = scanner.Err()
+		// Fail pending writes instead of blocking on a pipe nobody reads.
+		reader.CloseWithError(decoder.err)
 	}()
-
-	return &logEntryDecoder{consumer, writer, done}
+	return decoder
 }
 
 func (decoder *logEntryDecoder) Write(b []byte) (int, error) {
 	return decoder.writer.Write(b)
 }
 
-func (decoder *logEntryDecoder) Close() error {
-	return decoder.writer.Close()
-}
-
-func (decoder *logEntryDecoder) Wait() {
+// finish closes the decoder and reports the first error seen, preferring the
+// stream error over a decode error.
+func (decoder *logEntryDecoder) finish(streamErr error) error {
+	decoder.writer.Close()
 	<-decoder.done
+	if streamErr != nil {
+		return streamErr
+	}
+	return decoder.err
 }
 
 // ShowBuildLogs retrieves a specific build task logs.
@@ -273,30 +273,26 @@ func (client *Client) ShowBuildLogs(project, service, id string, consumer func(L
 		path = fmt.Sprintf("/projects/%s/services/%s/builds/%s/logs", project, service, id)
 	)
 	decoder := newLogEntryDecoder(consumer)
-	if err := client.streamRequest(http.MethodGet, path, decoder); err != nil {
-		return err
-	}
-	if err := decoder.Close(); err != nil {
-		return err
-	}
-	decoder.Wait()
-	return nil
+	err := client.streamOnce(path, decoder)
+	return decoder.finish(err)
 }
 
-// StreamBuildLogs streams the active build logs to stdout.
+// StreamBuildLogs streams the active build logs to stdout, reconnecting and
+// resuming if the connection is cut before the build finishes.
 func (client *Client) StreamBuildLogs(project, service, id string, consumer func(LogEntry)) error {
-	var (
-		path = fmt.Sprintf("/projects/%s/services/%s/builds/%s/logs?follow=true", project, service, id)
-	)
+	base := fmt.Sprintf("/projects/%s/services/%s/builds/%s/logs", project, service, id)
 	decoder := newLogEntryDecoder(consumer)
-	if err := client.streamRequest(http.MethodGet, path, decoder); err != nil {
-		return err
-	}
-	if err := decoder.Close(); err != nil {
-		return err
-	}
-	decoder.Wait()
-	return nil
+	err := client.follow(followOptions{
+		finite: true,
+		path: func(resumeAfter int) string {
+			params := url.Values{}
+			params.Set("follow", "true")
+			params.Set("keepalive", keepaliveInterval.String())
+			params.Set("skip", strconv.Itoa(resumeAfter))
+			return base + "?" + params.Encode()
+		},
+	}, decoder)
+	return decoder.finish(err)
 }
 
 // InspectBuild retrieves a specific build task.
@@ -703,6 +699,7 @@ func NewClient(endpoint, token string) (*Client, error) {
 		http: &http.Client{
 			Timeout: time.Minute,
 		},
+		stream: &http.Client{},
 	}
 	if err := client.check(); err != nil {
 		return nil, err

--- a/api/logstream.go
+++ b/api/logstream.go
@@ -2,11 +2,11 @@ package api
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"time"
 )
@@ -20,7 +20,10 @@ const (
 	keepaliveInterval = 20 * time.Second
 	// maxLogFrameSize bounds a single framed message.
 	maxLogFrameSize = 1 << 20
+)
 
+// Reconnect pacing, relaxed by tests.
+var (
 	reconnectBaseDelay = 250 * time.Millisecond
 	reconnectMaxDelay  = 5 * time.Second
 	// maxReconnectTries bounds consecutive reconnects that deliver nothing, so
@@ -35,84 +38,55 @@ type logFrame struct {
 	Keepalive bool   `json:"keepalive,omitempty"`
 }
 
-// lineWriter forwards whole log lines to w and counts them, holding back a
-// trailing partial line. Counting complete lines lets an interrupted follow
-// resume on a line boundary without duplicating or dropping output.
-type lineWriter struct {
-	w       io.Writer
-	pending []byte
-	lines   int
+// countingWriter forwards bytes untouched and records how many have been
+// delivered, so an interrupted follow can resume at the exact byte it stopped
+// at. Bytes pass straight through: a log that writes without trailing newlines
+// still appears as it arrives.
+type countingWriter struct {
+	w     io.Writer
+	bytes int
 }
 
-func (lw *lineWriter) Write(b []byte) (int, error) {
-	lw.pending = append(lw.pending, b...)
-	end := bytes.LastIndexByte(lw.pending, '\n')
-	if end < 0 {
-		return len(b), nil
-	}
-	complete := lw.pending[:end+1]
-	if _, err := lw.w.Write(complete); err != nil {
-		return 0, err
-	}
-	lw.lines += bytes.Count(complete, []byte{'\n'})
-	lw.pending = append(lw.pending[:0], lw.pending[end+1:]...)
-	return len(b), nil
-}
-
-// discardPartial drops the buffered partial line, which the server resends from
-// the last complete line when the stream resumes.
-func (lw *lineWriter) discardPartial() {
-	lw.pending = lw.pending[:0]
-}
-
-// flush writes out a trailing line that never got a newline.
-func (lw *lineWriter) flush() error {
-	if len(lw.pending) == 0 {
-		return nil
-	}
-	if _, err := lw.w.Write(lw.pending); err != nil {
-		return err
-	}
-	lw.pending = lw.pending[:0]
-	return nil
+func (cw *countingWriter) Write(b []byte) (int, error) {
+	n, err := cw.w.Write(b)
+	cw.bytes += n
+	return n, err
 }
 
 // followOptions describes a resumable log stream.
 type followOptions struct {
 	// path builds the request path for a connection that resumes after the
-	// given number of already-delivered lines.
+	// given number of already-delivered log bytes.
 	path func(resumeAfter int) string
 	// finite is true when the server ends the stream on purpose once the log is
 	// complete, as it does for a finished build.
 	finite bool
-	// skipped is the number of lines the caller asked to skip up front.
-	skipped int
 }
 
 // follow streams a log, reconnecting when the connection is cut. A follow can
 // idle for minutes at a time and intermediaries routinely drop idle
 // connections, so a cut is expected rather than fatal.
 func (client *Client) follow(opts followOptions, w io.Writer) error {
-	lw := &lineWriter{w: w, lines: opts.skipped}
-	defer lw.flush()
-
+	counter := &countingWriter{w: w}
 	for tries := 0; ; {
-		before := lw.lines
-		err := client.streamOnce(opts.path(lw.lines), lw)
+		before := counter.bytes
+		err := client.streamOnce(opts.path(counter.bytes), counter)
 		if err == nil && opts.finite {
 			return nil
 		}
 		if !retryable(err) {
 			return err
 		}
-		if lw.lines > before {
+		if counter.bytes > before {
 			tries = 0
 		} else if tries++; tries >= maxReconnectTries {
-			// Nothing is coming through; report the cut rather than spin.
+			// Nothing is coming through; report it rather than spin or, worse,
+			// exit successfully as though the log had ended.
+			if err == nil {
+				return fmt.Errorf("log stream closed %d times without delivering data", tries)
+			}
 			return err
 		}
-		// A cut mid-line leaves a partial the server resends on resume.
-		lw.discardPartial()
 		time.Sleep(reconnectDelay(tries))
 	}
 }
@@ -156,20 +130,13 @@ func (client *Client) streamOnce(path string, w io.Writer) error {
 			ServerError: parseErrorResponse(body),
 		}
 	}
-	if mediaType(resp.Header.Get("Content-Type")) == logStreamContentType {
+	if contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type")); err == nil && contentType == logStreamContentType {
 		return decodeFramedStream(resp.Body, w)
 	}
 	if _, err := io.Copy(w, resp.Body); err != nil && err != io.EOF {
 		return fmt.Errorf("copying request: %w", err)
 	}
 	return nil
-}
-
-func mediaType(contentType string) string {
-	if idx := bytes.IndexByte([]byte(contentType), ';'); idx >= 0 {
-		return contentType[:idx]
-	}
-	return contentType
 }
 
 // decodeFramedStream writes framed log payloads to w and drops keepalives.

--- a/api/logstream.go
+++ b/api/logstream.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	// logStreamContentType marks a response using the framed log stream
+	// protocol, where the server interleaves keepalives with log data.
+	logStreamContentType = "application/x-ndjson"
+	// keepaliveInterval is how often the server is asked to send a heartbeat on
+	// an otherwise idle follow stream.
+	keepaliveInterval = 20 * time.Second
+	// maxLogFrameSize bounds a single framed message.
+	maxLogFrameSize = 1 << 20
+
+	reconnectBaseDelay = 250 * time.Millisecond
+	reconnectMaxDelay  = 5 * time.Second
+	// maxReconnectTries bounds consecutive reconnects that deliver nothing, so
+	// a log that can no longer be read ends instead of looping.
+	maxReconnectTries = 8
+)
+
+// logFrame mirrors the server's framed log stream protocol. Data is
+// base64-encoded by encoding/json.
+type logFrame struct {
+	Data      []byte `json:"data,omitempty"`
+	Keepalive bool   `json:"keepalive,omitempty"`
+}
+
+// lineWriter forwards whole log lines to w and counts them, holding back a
+// trailing partial line. Counting complete lines lets an interrupted follow
+// resume on a line boundary without duplicating or dropping output.
+type lineWriter struct {
+	w       io.Writer
+	pending []byte
+	lines   int
+}
+
+func (lw *lineWriter) Write(b []byte) (int, error) {
+	lw.pending = append(lw.pending, b...)
+	end := bytes.LastIndexByte(lw.pending, '\n')
+	if end < 0 {
+		return len(b), nil
+	}
+	complete := lw.pending[:end+1]
+	if _, err := lw.w.Write(complete); err != nil {
+		return 0, err
+	}
+	lw.lines += bytes.Count(complete, []byte{'\n'})
+	lw.pending = append(lw.pending[:0], lw.pending[end+1:]...)
+	return len(b), nil
+}
+
+// discardPartial drops the buffered partial line, which the server resends from
+// the last complete line when the stream resumes.
+func (lw *lineWriter) discardPartial() {
+	lw.pending = lw.pending[:0]
+}
+
+// flush writes out a trailing line that never got a newline.
+func (lw *lineWriter) flush() error {
+	if len(lw.pending) == 0 {
+		return nil
+	}
+	if _, err := lw.w.Write(lw.pending); err != nil {
+		return err
+	}
+	lw.pending = lw.pending[:0]
+	return nil
+}
+
+// followOptions describes a resumable log stream.
+type followOptions struct {
+	// path builds the request path for a connection that resumes after the
+	// given number of already-delivered lines.
+	path func(resumeAfter int) string
+	// finite is true when the server ends the stream on purpose once the log is
+	// complete, as it does for a finished build.
+	finite bool
+	// skipped is the number of lines the caller asked to skip up front.
+	skipped int
+}
+
+// follow streams a log, reconnecting when the connection is cut. A follow can
+// idle for minutes at a time and intermediaries routinely drop idle
+// connections, so a cut is expected rather than fatal.
+func (client *Client) follow(opts followOptions, w io.Writer) error {
+	lw := &lineWriter{w: w, lines: opts.skipped}
+	defer lw.flush()
+
+	for tries := 0; ; {
+		before := lw.lines
+		err := client.streamOnce(opts.path(lw.lines), lw)
+		if err == nil && opts.finite {
+			return nil
+		}
+		if !retryable(err) {
+			return err
+		}
+		if lw.lines > before {
+			tries = 0
+		} else if tries++; tries >= maxReconnectTries {
+			// Nothing is coming through; report the cut rather than spin.
+			return err
+		}
+		// A cut mid-line leaves a partial the server resends on resume.
+		lw.discardPartial()
+		time.Sleep(reconnectDelay(tries))
+	}
+}
+
+// retryable reports whether a stream ended in a way a reconnect can recover
+// from. A response the server rejected outright will be rejected again.
+func retryable(err error) bool {
+	var statusErr Error
+	return !errors.As(err, &statusErr)
+}
+
+func reconnectDelay(tries int) time.Duration {
+	delay := reconnectBaseDelay << tries
+	if delay > reconnectMaxDelay || delay <= 0 {
+		return reconnectMaxDelay
+	}
+	return delay
+}
+
+// streamOnce runs a single streaming request, decoding framed responses and
+// copying raw ones. A nil error means the server closed the stream.
+func (client *Client) streamOnce(path string, w io.Writer) error {
+	req, err := http.NewRequest(http.MethodGet, client.Endpoint+path, nil)
+	if err != nil {
+		return fmt.Errorf("client request: %w", err)
+	}
+	req.Header.Add("Authorization", "Bearer "+client.Token)
+
+	resp, err := client.stream.Do(req)
+	if err != nil {
+		return fmt.Errorf("submitting request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("fetching response: %w", err)
+		}
+		return Error{
+			StatusCode:  resp.StatusCode,
+			ServerError: parseErrorResponse(body),
+		}
+	}
+	if mediaType(resp.Header.Get("Content-Type")) == logStreamContentType {
+		return decodeFramedStream(resp.Body, w)
+	}
+	if _, err := io.Copy(w, resp.Body); err != nil && err != io.EOF {
+		return fmt.Errorf("copying request: %w", err)
+	}
+	return nil
+}
+
+func mediaType(contentType string) string {
+	if idx := bytes.IndexByte([]byte(contentType), ';'); idx >= 0 {
+		return contentType[:idx]
+	}
+	return contentType
+}
+
+// decodeFramedStream writes framed log payloads to w and drops keepalives.
+func decodeFramedStream(r io.Reader, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxLogFrameSize)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var frame logFrame
+		if err := json.Unmarshal(line, &frame); err != nil {
+			return fmt.Errorf("decoding log frame: %w", err)
+		}
+		if frame.Keepalive {
+			continue
+		}
+		if _, err := w.Write(frame.Data); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading log stream: %w", err)
+	}
+	return nil
+}

--- a/api/logstream_test.go
+++ b/api/logstream_test.go
@@ -1,0 +1,221 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func newTestClient(endpoint string) *Client {
+	return &Client{Endpoint: endpoint, stream: &http.Client{}}
+}
+
+// cutConnection ends a response without a terminating chunk, the way an idle
+// connection reaper does.
+func cutConnection(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		t.Error("response writer is not hijackable")
+		return
+	}
+	conn, _, err := hijacker.Hijack()
+	if err != nil {
+		t.Errorf("hijack: %v", err)
+		return
+	}
+	conn.Close()
+}
+
+func TestLineWriter_HoldsBackPartialLines(t *testing.T) {
+	var out bytes.Buffer
+	lw := &lineWriter{w: &out}
+
+	for _, chunk := range []string{"one\ntw", "o\nthree"} {
+		if _, err := lw.Write([]byte(chunk)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	if got, want := out.String(), "one\ntwo\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if lw.lines != 2 {
+		t.Errorf("got %d lines, want 2", lw.lines)
+	}
+	if err := lw.flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if got, want := out.String(), "one\ntwo\nthree"; got != want {
+		t.Errorf("after flush got %q, want %q", got, want)
+	}
+}
+
+func TestDecodeFramedStream_DropsKeepalives(t *testing.T) {
+	var body bytes.Buffer
+	for _, frame := range []logFrame{
+		{Data: []byte("hello\n")},
+		{Keepalive: true},
+		{Keepalive: true},
+		{Data: []byte("world\n")},
+	} {
+		if err := json.NewEncoder(&body).Encode(frame); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+
+	var out bytes.Buffer
+	if err := decodeFramedStream(&body, &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, want := out.String(), "hello\nworld\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestDecodeFramedStream_WireFormat pins the bytes the API emits. The matching
+// test lives in the platform repository; change both together.
+func TestDecodeFramedStream_WireFormat(t *testing.T) {
+	body := strings.NewReader(`{"data":"aGVsbG8K"}` + "\n" + `{"keepalive":true}` + "\n")
+
+	var out bytes.Buffer
+	if err := decodeFramedStream(body, &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got, want := out.String(), "hello\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestFollow_ResumesAfterCut is the regression test for log tails dying on an
+// idle connection: the stream is cut mid-line and must resume on the next line
+// boundary without dropping or duplicating output.
+func TestFollow_ResumesAfterCut(t *testing.T) {
+	log := []string{"line1\n", "line2\n", "line3\n", "line4\n"}
+
+	var mu sync.Mutex
+	var skips []int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		skip, err := strconv.Atoi(r.URL.Query().Get("skip"))
+		if err != nil {
+			t.Errorf("bad skip %q: %v", r.URL.Query().Get("skip"), err)
+			return
+		}
+		mu.Lock()
+		attempt := len(skips)
+		skips = append(skips, skip)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if attempt == 0 {
+			// Two whole lines plus a partial one, then a cut.
+			fmt.Fprint(w, log[0], log[1], "lin")
+			w.(http.Flusher).Flush()
+			cutConnection(t, w)
+			return
+		}
+		for _, line := range log[skip:] {
+			fmt.Fprint(w, line)
+		}
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	client := newTestClient(srv.URL)
+	err := client.follow(followOptions{
+		finite: true,
+		path: func(resumeAfter int) string {
+			return "/logs?skip=" + strconv.Itoa(resumeAfter)
+		},
+	}, &out)
+	if err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+
+	if got, want := out.String(), strings.Join(log, ""); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if want := []int{0, 2}; !equalInts(skips, want) {
+		t.Errorf("got skips %v, want %v", skips, want)
+	}
+}
+
+func TestFollow_DoesNotRetryRejectedRequests(t *testing.T) {
+	var mu sync.Mutex
+	var requests int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":"service not found"}`)
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	err := client.follow(followOptions{
+		path: func(int) string { return "/logs?skip=0" },
+	}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 1 {
+		t.Errorf("got %d requests, want 1", requests)
+	}
+}
+
+func TestFollow_DecodesFramedResponses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", logStreamContentType)
+		enc := json.NewEncoder(w)
+		for _, frame := range []logFrame{
+			{Keepalive: true},
+			{Data: []byte("hello\n")},
+			{Keepalive: true},
+			{Data: []byte("world\n")},
+		} {
+			if err := enc.Encode(frame); err != nil {
+				t.Errorf("encode: %v", err)
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	var out bytes.Buffer
+	client := newTestClient(srv.URL)
+	if err := client.follow(followOptions{
+		finite: true,
+		path:   func(int) string { return "/logs?skip=0" },
+	}, &out); err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if got, want := out.String(), "hello\nworld\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/api/logstream_test.go
+++ b/api/logstream_test.go
@@ -10,10 +10,19 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func newTestClient(endpoint string) *Client {
 	return &Client{Endpoint: endpoint, stream: &http.Client{}}
+}
+
+// withFastReconnects shortens the reconnect backoff for the duration of a test.
+func withFastReconnects(t *testing.T) func() {
+	t.Helper()
+	base, max := reconnectBaseDelay, reconnectMaxDelay
+	reconnectBaseDelay, reconnectMaxDelay = time.Millisecond, 2*time.Millisecond
+	return func() { reconnectBaseDelay, reconnectMaxDelay = base, max }
 }
 
 // cutConnection ends a response without a terminating chunk, the way an idle
@@ -33,27 +42,27 @@ func cutConnection(t *testing.T, w http.ResponseWriter) {
 	conn.Close()
 }
 
-func TestLineWriter_HoldsBackPartialLines(t *testing.T) {
+// TestCountingWriter_PassesBytesStraightThrough guards against reintroducing
+// line buffering: output with no trailing newline must still appear as it
+// arrives, not be withheld until a newline shows up.
+func TestCountingWriter_PassesBytesStraightThrough(t *testing.T) {
 	var out bytes.Buffer
-	lw := &lineWriter{w: &out}
+	cw := &countingWriter{w: &out}
 
-	for _, chunk := range []string{"one\ntw", "o\nthree"} {
-		if _, err := lw.Write([]byte(chunk)); err != nil {
+	for _, chunk := range []string{"progress: 10%\r", "progress: 20%\r"} {
+		if _, err := cw.Write([]byte(chunk)); err != nil {
 			t.Fatalf("write: %v", err)
+		}
+		if out.Len() == 0 {
+			t.Fatal("writer withheld output that contained no newline")
 		}
 	}
 
-	if got, want := out.String(), "one\ntwo\n"; got != want {
+	if got, want := out.String(), "progress: 10%\rprogress: 20%\r"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
-	if lw.lines != 2 {
-		t.Errorf("got %d lines, want 2", lw.lines)
-	}
-	if err := lw.flush(); err != nil {
-		t.Fatalf("flush: %v", err)
-	}
-	if got, want := out.String(), "one\ntwo\nthree"; got != want {
-		t.Errorf("after flush got %q, want %q", got, want)
+	if cw.bytes != out.Len() {
+		t.Errorf("got %d bytes counted, want %d", cw.bytes, out.Len())
 	}
 }
 
@@ -94,36 +103,34 @@ func TestDecodeFramedStream_WireFormat(t *testing.T) {
 }
 
 // TestFollow_ResumesAfterCut is the regression test for log tails dying on an
-// idle connection: the stream is cut mid-line and must resume on the next line
-// boundary without dropping or duplicating output.
+// idle connection: the stream is cut mid-line and must resume at the exact byte
+// it stopped at, without dropping or duplicating output.
 func TestFollow_ResumesAfterCut(t *testing.T) {
-	log := []string{"line1\n", "line2\n", "line3\n", "line4\n"}
+	const log = "line1\nline2\nline3\nline4\n"
 
 	var mu sync.Mutex
-	var skips []int
+	var offsets []int
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		skip, err := strconv.Atoi(r.URL.Query().Get("skip"))
-		if err != nil {
-			t.Errorf("bad skip %q: %v", r.URL.Query().Get("skip"), err)
+		offset, err := strconv.Atoi(r.URL.Query().Get("offset"))
+		if err != nil || offset < 0 || offset > len(log) {
+			t.Errorf("bad offset %q: %v", r.URL.Query().Get("offset"), err)
 			return
 		}
 		mu.Lock()
-		attempt := len(skips)
-		skips = append(skips, skip)
+		attempt := len(offsets)
+		offsets = append(offsets, offset)
 		mu.Unlock()
 
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		if attempt == 0 {
-			// Two whole lines plus a partial one, then a cut.
-			fmt.Fprint(w, log[0], log[1], "lin")
+			// Stop mid-line, then cut without a terminating chunk.
+			fmt.Fprint(w, log[:15])
 			w.(http.Flusher).Flush()
 			cutConnection(t, w)
 			return
 		}
-		for _, line := range log[skip:] {
-			fmt.Fprint(w, line)
-		}
+		fmt.Fprint(w, log[offset:])
 	}))
 	defer srv.Close()
 
@@ -132,20 +139,40 @@ func TestFollow_ResumesAfterCut(t *testing.T) {
 	err := client.follow(followOptions{
 		finite: true,
 		path: func(resumeAfter int) string {
-			return "/logs?skip=" + strconv.Itoa(resumeAfter)
+			return "/logs?offset=" + strconv.Itoa(resumeAfter)
 		},
 	}, &out)
 	if err != nil {
 		t.Fatalf("follow: %v", err)
 	}
 
-	if got, want := out.String(), strings.Join(log, ""); got != want {
-		t.Errorf("got %q, want %q", got, want)
+	if got := out.String(); got != log {
+		t.Errorf("got %q, want %q", got, log)
 	}
 	mu.Lock()
 	defer mu.Unlock()
-	if want := []int{0, 2}; !equalInts(skips, want) {
-		t.Errorf("got skips %v, want %v", skips, want)
+	if want := []int{0, 15}; !equalInts(offsets, want) {
+		t.Errorf("got offsets %v, want %v", offsets, want)
+	}
+}
+
+// TestFollow_ReportsRepeatedEmptyCloses covers a server that keeps closing the
+// stream without sending anything: the command must fail loudly rather than
+// exit successfully as though the log had ended.
+func TestFollow_ReportsRepeatedEmptyCloses(t *testing.T) {
+	defer withFastReconnects(t)()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	}))
+	defer srv.Close()
+
+	client := newTestClient(srv.URL)
+	err := client.follow(followOptions{
+		path: func(resumeAfter int) string { return "/logs?offset=" + strconv.Itoa(resumeAfter) },
+	}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected an error after repeated empty closes")
 	}
 }
 
@@ -165,7 +192,7 @@ func TestFollow_DoesNotRetryRejectedRequests(t *testing.T) {
 
 	client := newTestClient(srv.URL)
 	err := client.follow(followOptions{
-		path: func(int) string { return "/logs?skip=0" },
+		path: func(int) string { return "/logs?offset=0" },
 	}, &bytes.Buffer{})
 	if err == nil {
 		t.Fatal("expected an error")
@@ -199,7 +226,7 @@ func TestFollow_DecodesFramedResponses(t *testing.T) {
 	client := newTestClient(srv.URL)
 	if err := client.follow(followOptions{
 		finite: true,
-		path:   func(int) string { return "/logs?skip=0" },
+		path:   func(int) string { return "/logs?offset=0" },
 	}, &out); err != nil {
 		t.Fatalf("follow: %v", err)
 	}

--- a/cmd/builds.go
+++ b/cmd/builds.go
@@ -196,7 +196,7 @@ var buildWatchCmd = &cobra.Command{
 			bar.Describe("Scheduling build onto worker ...")
 		}
 
-		client.StreamBuildLogs(cfg.Project(), cfg.Service(), latestBuildID, func(le api.LogEntry) {
+		if err := client.StreamBuildLogs(cfg.Project(), cfg.Service(), latestBuildID, func(le api.LogEntry) {
 			switch le.Stage {
 			case api.LogEntryStageUnspecified:
 				bar.Describe("Processing ...")
@@ -208,7 +208,11 @@ var buildWatchCmd = &cobra.Command{
 			bar.AddDetail(formatLogEntry(&le, terminalWidth))
 			fmt.Printf("\n\033[1A\033[K")
 			bar.RenderBlank()
-		})
+		}); err != nil {
+			bar.Finish()
+			fmt.Println()
+			return fmt.Errorf("streaming build logs: %w", err)
+		}
 
 		build, err = client.InspectBuild(cfg.Project(), cfg.Service(), latestBuildID)
 		if err != nil {


### PR DESCRIPTION
## Why

`valar service logs -f` dies after ~30 seconds with a bare timeout. The cause is not a timeout in this repo — `streamRequest` already set `client.http.Timeout = 0` for streams. It was that a followed log was **one request and one `io.Copy`**: no reconnect, no resume, no heartbeat handling. A tail sends nothing at all while the log is idle, so any intermediary that reaps idle connections ended the command, and the CLI had no way to recover or even explain what happened.

Worse, a *clean* close after 30s made `io.Copy` return `io.EOF`, `streamRequest` return `nil`, and the command exit 0 with no message whatsoever.

## What changed

**Reconnect with byte-exact resume.** Follows now reconnect when the connection is cut and resume at the exact byte they stopped at, so nothing is dropped or duplicated. Bytes pass straight through to the writer as they arrive — output that never ends in a newline (progress bars, prompts) still streams live. Requests the server rejected outright (404, 401) are not retried, and consecutive reconnects that deliver nothing are bounded so a log that can no longer be read fails loudly instead of looping.

**Keepalives.** Follows ask the server for heartbeats and decode the framed response that enables (valar/platform#79). Against a server without that support the parameter is ignored and the reconnect logic still covers us, so the two repos can ship independently.

**Shared client timeout.** `streamRequest` and `request` mutated `client.http.Timeout` on the *same* `http.Client` before each call. That is a latent race that could cap a stream at a minute; streams now get their own client.

## Also fixed

Two silent failures found along the way:

- `logEntryDecoder` never checked `scanner.Err()`. A build log line over 64 KiB (`bufio.ErrTooLong`) ended the scan goroutine, after which `io.Copy` blocked forever on the pipe — a hang with no error. The buffer is now larger and the error is propagated and closes the pipe.
- `build watch` discarded the return value of `StreamBuildLogs` entirely, so a stream failure silently ended the watch and the command carried on as if the build had been followed.

## Review pass

The first commit resumed by counting whole lines, which meant buffering a trailing partial line until its newline arrived — a regression that would have made a service writing without newlines print nothing at all, with an unbounded buffer. The second commit replaces that with byte offsets, which removes the buffer entirely and also avoids a pathological server-side seek (logd walks the log a byte at a time when seeking by line). It also fixes exhausted retries returning nil (silent exit 0) and switches content-type parsing to `mime.ParseMediaType`.

## Known limitation

`--tail` is anchored to the end of the log, so there is no absolute byte position to resume from; a reconnect re-anchors to the current end and may skip lines written during the gap (milliseconds). The default `-f` path resumes exactly. With keepalives in place, reconnects should be rare either way.

## Testing

`go test ./...` passes. `api/logstream_test.go` covers keepalive decoding, rejected requests not being retried, retry exhaustion being reported, and `TestFollow_ResumesAfterCut` — an httptest server that cuts the connection mid-line and asserts the resumed stream reproduces the log exactly with the expected byte offsets. `TestCountingWriter_PassesBytesStraightThrough` guards against reintroducing line buffering, and `TestDecodeFramedStream_WireFormat` pins the wire bytes against the matching test in the platform repo.