### PR TITLE
Repair the release workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,156 +1,110 @@
 name: Go
+
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+
+permissions:
+  contents: read
+
 jobs:
-  build:
-    name: Build
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.21
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.21
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-    - name: Get dependencies
-      run: go get -v -t -d ./...
-    - name: Set version environment
-      run: echo "VALAR_VERSION=$(echo ${GITHUB_REF:10})" >> $GITHUB_ENV
-    - name: Build
-      run: |
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags "-X valar/cli/cmd.version=$VALAR_VERSION -s -w -extldflags \"-static\"" -o valar_linux_amd64 .
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -a -tags netgo -ldflags "-X valar/cli/cmd.version=$VALAR_VERSION -s -w -extldflags \"-static\"" -o valar_linux_arm .
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -tags netgo -ldflags "-X valar/cli/cmd.version=$VALAR_VERSION -s -w -extldflags \"-static\"" -o valar_linux_arm64 .
-        CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -tags netgo -ldflags "-X valar/cli/cmd.version=$VALAR_VERSION -s -w -extldflags \"-static\"" -o valar_darwin_amd64 .
-        CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -tags netgo -ldflags "-X valar/cli/cmd.version=$VALAR_VERSION -s -w -extldflags \"-static\"" -o valar_darwin_arm64 .
-    - uses: actions/upload-artifact@v4
-      with:
-        name: valar_darwin_amd64
-        path: valar_darwin_amd64
-    - uses: actions/upload-artifact@v4
-      with:
-        name: valar_darwin_arm64
-        path: valar_darwin_arm64
-    - uses: actions/upload-artifact@v4
-      with:
-        name: valar_linux_amd64
-        path: valar_linux_amd64
-    - uses: actions/upload-artifact@v4
-      with:
-        name: valar_linux_arm
-        path: valar_linux_arm
-    - uses: actions/upload-artifact@v4
-      with:
-        name: valar_linux_arm64
-        path: valar_linux_arm64
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./...
+
   release:
     name: Release
+    needs: [test]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [build]
+    permissions:
+      contents: write
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        name: valar_linux_arm
-    - uses: actions/download-artifact@v4
-      with:
-        name: valar_linux_arm64
-    - uses: actions/download-artifact@v4
-      with:
-        name: valar_linux_amd64
-    - uses: actions/download-artifact@v4
-      with:
-        name: valar_darwin_amd64
-    - uses: actions/download-artifact@v4
-      with:
-        name: valar_darwin_arm64
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
-        draft: false
-        prerelease: false
-    - name: Upload release asset (linux_amd64)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./valar_linux_amd64
-        asset_name: valar_linux_amd64
-        asset_content_type: binary/octet-stream
-    - name: Upload release asset (linux_arm64)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./valar_linux_arm64
-        asset_name: valar_linux_arm64
-        asset_content_type: binary/octet-stream
-    - name: Upload release asset (linux_arm)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./valar_linux_arm
-        asset_name: valar_linux_arm
-        asset_content_type: binary/octet-stream
-    - name: Upload release asset (darwin_amd64)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./valar_darwin_amd64
-        asset_name: valar_darwin_amd64
-        asset_content_type: binary/octet-stream
-    - name: Upload release asset (darwin_arm64)
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./valar_darwin_arm64
-        asset_name: valar_darwin_arm64
-        asset_content_type: binary/octet-stream
-  homebrew: 
-    name: Update homebrew-tap
-    runs-on: macos-latest
-    needs: [build, release]
-    steps:
-      - uses: actions/checkout@v2  
-      - name: Setup SSH Keys and known_hosts
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # The -X path must be the full module path of the package holding the
+      # variable. An -X for a symbol that does not exist is silently ignored, so
+      # a wrong path leaves every released binary reporting an empty version.
+      - name: Build release binaries
         env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          VALAR_VERSION: ${{ github.ref_name }}
+        run: |
+          set -eu
+          mkdir -p dist
+          for target in linux/amd64 linux/arm linux/arm64 darwin/amd64 darwin/arm64; do
+            os="${target%/*}"
+            arch="${target#*/}"
+            CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build \
+              -a -tags netgo \
+              -ldflags "-X github.com/valar/cli/cmd.version=${VALAR_VERSION} -s -w -extldflags \"-static\"" \
+              -o "dist/valar_${os}_${arch}" .
+          done
+
+      - name: Verify the version was stamped
+        run: |
+          set -eu
+          got="$(./dist/valar_linux_amd64 --version)"
+          case "$got" in
+            *"${GITHUB_REF_NAME#v}"*) ;;
+            *) echo "binary reports '$got', expected it to contain ${GITHUB_REF_NAME#v}"; exit 1 ;;
+          esac
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes
+
+  homebrew:
+    name: Update homebrew-tap
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure deploy key
+        env:
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         run: |
+          set -eu
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${DEPLOY_KEY}"
+          install -m 600 /dev/stdin ~/.ssh/id_deploy <<< "${DEPLOY_KEY}"
+
+      # sed writes through a temporary file: redirecting into the file being
+      # read truncates it before it is opened.
+      - name: Bump formula
+        env:
+          GIT_SSH_COMMAND: ssh -i ~/.ssh/id_deploy -o IdentitiesOnly=yes
+        run: |
+          set -eu
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Actions"
-      - name: Extract version
-        id: get_version
-        run: |
-          echo ::set-output name=version::${GITHUB_REF#refs/*/}
-          echo ::set-output name=short_version::$(echo ${GITHUB_REF#refs/*/} | cut -c2-)
-      - name: Bump archive version
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          git clone git@github.com:valar/homebrew-tap.git ~/valar-tap && cd ~/valar-tap
-          NEW_URL="https://github.com/valar/cli/archive/refs/tags/${{ steps.get_version.outputs.version }}.tar.gz"
-          NEW_SHA256="$(curl -sSL $NEW_URL | sha256sum -)"
-          awk -v new_url="$NEW_URL" '{gsub(/url ".*"/, "url \""new_url"\"")} 1' Formula/valar.rb > Formula/valar.rb
-          awk -v new_sha256="$NEW_SHA256" '{gsub(/sha256 ".*"/, "sha256 \""new_sha256"\"")} 1' Formula/valar.rb > Formula/valar.rb
-          git commit -a -m "Bump version to ${{ steps.get_version.outputs.version }}"
-          git push -u
-    
+          git clone git@github.com:valar/homebrew-tap.git tap
+          cd tap
+          url="https://github.com/valar/cli/archive/refs/tags/${GITHUB_REF_NAME}.tar.gz"
+          sha="$(curl -sSL "$url" | sha256sum | cut -d' ' -f1)"
+          tmp="$(mktemp)"
+          sed -e "s|url \".*\"|url \"${url}\"|" \
+              -e "s|sha256 \".*\"|sha256 \"${sha}\"|" \
+              Formula/valar.rb > "$tmp"
+          mv "$tmp" Formula/valar.rb
+          if git diff --quiet; then
+            echo "formula already up to date"
+            exit 0
+          fi
+          git commit -am "Bump valar to ${GITHUB_REF_NAME}"
+          git push

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,8 +14,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: go build ./...
@@ -30,8 +30,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## Why

`v4.3.0` was tagged and pushed five months ago but **never produced a release** — the last published release is v4.2.1. The run failed on its very first step, `Set up Go 1.21`, so the release and homebrew jobs never started.

The workflow was pinned to `actions/setup-go@v1`, `actions/checkout@v1` and the archived `actions/create-release` / `actions/upload-release-asset`, all of which run on Node runtimes GitHub has retired. It also asked for Go 1.21 while `go.mod` now requires 1.24.

## What changed

- Current actions (`checkout@v4`, `setup-go@v5`), with the Go version read from `go.mod` so the two cannot drift apart again.
- Publish with `gh release create` rather than the archived release actions — no third-party action needed.
- Run `build`, `vet` and `test` on pushes and pull requests. The repository has tests now and nothing was running them.

## The version was never being stamped

The workflow set `-X valar/cli/cmd.version`, but the module is `github.com/valar/cli`. The linker **silently ignores** `-X` for a symbol that does not exist, so the variable stayed empty in every published binary — and because `rootCmd.Version` was empty, cobra never registered a `--version` flag at all. Verified locally against this branch:

```
$ go build -ldflags "-X github.com/valar/cli/cmd.version=v4.4.0" -o valar . && ./valar --version
Valar CLI v4.4.0

$ go build -ldflags "-X valar/cli/cmd.version=v4.4.0" -o valar . && ./valar --version
Error: unknown flag: --version
```

A `Verify the version was stamped` step now asserts the built binary reports the tag before anything is published, so this cannot regress silently.

## Homebrew job

Two latent bugs that would have fired the first time it actually ran:

- `awk ... Formula/valar.rb > Formula/valar.rb` — the shell truncates the file before awk opens it, destroying the formula. Now written via a temporary file.
- `sha256sum -` emits `<hash>  -`, and the trailing ` -` was being substituted into the formula. Now takes the first field.

Also replaces the deprecated `::set-output`, and skips the commit when the formula is already current instead of failing on an empty commit.